### PR TITLE
Replace networkx-stubs with types-networkx

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**1.0.8 - 06/08/26**
+ 
+ - Replace networkx-stubs with types-networkx in the networkx extra
+
 **1.0.7 - 04/14/26**
  
  - Add vbu pin

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
         "pyarrow": ["pyarrow"],
         "networkx": [
             "networkx",
-            "types-networkx<=3.6.1.20260518",
+            "types-networkx",
         ],
         "requests": [
             "requests",

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
         "pyarrow": ["pyarrow"],
         "networkx": [
             "networkx",
-            "networkx-stubs",
+            "types-networkx<=3.6.1.20260518",
         ],
         "requests": [
             "requests",


### PR DESCRIPTION
### Description
- *Category*: other/misc
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-7195

### Changes and notes
The `networkx` extra pulled in `networkx-stubs` (0.0.1), a low-quality autogenerated stub package whose `algorithms/dag.pyi` types `topological_sort(G) -> None` — wrong, it returns a generator. That false-positive forced a `# type: ignore` in `vivarium-engine`'s resource manager (MIC-6218).

This swaps in `types-networkx`, the maintained typeshed-derived stubs, which type `topological_sort` correctly as `-> Generator[_Node]` (and `DiGraph` as generic over its node type). Pinned with `<=3.6.1.20260518`, mirroring the `pandas-stubs<=...` precedent, to insulate the build from future stub-driven breakage.

`vivarium-engine` is the only consumer of the networkx extra in the ecosystem; the corresponding engine cleanup (remove the ignore, type the resource graph as `nx.DiGraph[Resource]`) is staged in ihmeuw/vivarium-suite and depends on this release.

**Release note:** the CHANGELOG is dated `06/08/26`; `deploy.yml` validates that against the release day, so bump the date if this merges/deploys on a different day.

### Testing
- Installed the `networkx` extra with `types-networkx==3.6.1.20260518` into a `vivarium-engine` dev env; `make mypy` passes for engine with the ignore removed and `DiGraph[Resource]` annotations in place (953 tests still green).